### PR TITLE
Some formatting/style improvements, and doc updates

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -30,10 +30,16 @@ config WS2812_T1H
     help
 	Time interval the signal should be high when a 1 bit is transmitted.
 
-config WS2812_TL
-	int "low time for either bit"
+config WS2812_T1L
+	int "0 bit low time"
     default 52
     help
-	Time interval the signal should be low followed by the high time for either bit.
+	Time interval the signal should be low followed by the high time for a 0 bit.
+
+config WS2812_T0L
+	int "1 bit low time"
+    default 52
+    help
+	Time interval the signal should be low followed by the high time for a 1 bit.
 
 endmenu

--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ This code assumes you are using FreeRTOS.
 Because of the way the ESP32 RMT peripheral works this technique for driving NeoPixels is a little heavy on memory usage. It requires (4 bytes * 24 * NUM_LEDS) of dedicated memory.
 
 ## Usage
-Copy the source and header files into your project. Update the following defines based on your project needs / arrangement. 
-- NUM_LEDS
-- LED_RMT_TX_CHANNEL
-- LED_RMT_TX_GPIO
+Copy the source and header files into your project. Update the following config options based on your project needs / arrangement.
+
+- CONFIG_WS2812_NUM_LEDS
+- CONFIG_WS2812_LED_RMT_TX_GPIO
+- CONFIG_WS2812_T0H  // 0 bit high time
+- CONFIG_WS2812_T1H  // 1 bit high time
+- CONFIG_WS2812_T0L  // 0 bit low time
+- CONFIG_WS2812_T1L  // 1 bit low time
 
 In your application init section call `void ws2812_control_init(void)` to initialize the RMT peripheral with the correct configuration.
 
@@ -25,14 +29,14 @@ Whenever you need to update the LEDs simply call `void ws2812_write_leds(struct 
 
 ### Example
 ```c
-#define NUM_LEDS 3
 #include "ws2812_control.h"
 
 #define RED   0xFF0000
 #define GREEN 0x00FF00
 #define BLUE  0x0000FF
 
-int main(void) {
+int main(void)
+{
   ws2812_control_init();
 
   struct led_state new_state;
@@ -44,12 +48,32 @@ int main(void) {
 }
 ```
 
-
 ### Timing
 This code is tuned based on the timing specifications indicated in the following datasheet provided by Sparkfun: https://cdn.sparkfun.com/datasheets/Components/LED/COM-12877.pdf
 
-I'm pretty sure there are variations of the NeoPixel out there that have different timing requirements to you may have to tweak the code accordingly.
+#### LED TIMINGS, per their datasheets:
 
+##### WS2811: (2.5us bit time, 400Kbps)
+    T0H: 0.5us <-- 0 bit
+    T0L: 2.0us
+    T1H: 1.2us <-- 1 bit
+    T1L: 1.3us
+    RES: 50us
+##### WS2812: (1.25us bit time, 800Kbps)
+    T0H: 0.35us <-- 0 bit
+    T0L: 0.8us
+    T1H: 0.7us <-- 1 bit
+    T1L: 0.6us
+    RES: 50us
+##### WS2812b: (1.25us bit time, 800Kbps)
+    T0H: 0.4us <-- 0 bit
+    T0L: 0.85us
+    T1H: 0.8us <-- 1 bit
+    T1L: 0.45us
+    RES: 50us
+
+If you use WiFi, you may find that it causes problems with the LEDs not being set correctly.
+You can use xTaskCreatePinnedToCore to run the thread which initializes the library (and registers the rtm_isr), to run on core 1.
 
 ## Contribution
 If you find a problem or have ideas about how to improve this please submit a PR and I will happily review and merge. Thanks!

--- a/ws2812_control.c
+++ b/ws2812_control.c
@@ -4,25 +4,26 @@
 #include "esp_check.h"
 
 // Configure these based on your project needs using menuconfig ********
-#define LED_RMT_TX_CHANNEL			CONFIG_WS2812_LED_RMT_TX_CHANNEL
+#define LED_RMT_TX_CHANNEL		CONFIG_WS2812_LED_RMT_TX_CHANNEL
 #define LED_RMT_TX_GPIO			CONFIG_WS2812_LED_RMT_TX_GPIO
 // ****************************************************
 
-#define BITS_PER_LED_CMD 24 
-#define LED_BUFFER_ITEMS ((NUM_LEDS * BITS_PER_LED_CMD))
+#define BITS_PER_LED_CMD	24
+#define LED_BUFFER_ITEMS	(NUM_LEDS * BITS_PER_LED_CMD)
 
 // These values are determined by measuring pulse timing with logic analyzer and adjusting to match datasheet. 
-#define T0H CONFIG_WS2812_T0H  // 0 bit high time
-#define T1H CONFIG_WS2812_T1H  // 1 bit high time
-#define TL  CONFIG_WS2812_TL  // low time for either bit
+#define T0H	CONFIG_WS2812_T0H  // 0 bit high time
+#define T1H	CONFIG_WS2812_T1H  // 1 bit high time
+#define T0L	CONFIG_WS2812_T0L  // low time for either bit
+#define T1L	CONFIG_WS2812_T1L
 
 // Tag for log messages
 static const char *TAG = "NeoPixel WS2812 Driver";
 
 // This is the buffer which the hw peripheral will access while pulsing the output pin
-rmt_item32_t led_data_buffer[LED_BUFFER_ITEMS];
+static rmt_item32_t led_data_buffer[LED_BUFFER_ITEMS];
 
-void setup_rmt_data_buffer(struct led_state new_state);
+static void setup_rmt_data_buffer(struct led_state new_state);
 
 esp_err_t ws2812_control_init(void)
 {
@@ -35,7 +36,7 @@ esp_err_t ws2812_control_init(void)
     .tx_config.carrier_en = false,
     .tx_config.idle_output_en = true,
     .tx_config.idle_level = 0,
-    .clk_div = 2,
+    .clk_div = 2
   };
 
   ESP_RETURN_ON_ERROR(rmt_config(&config), TAG, "Failed to configure RMT");
@@ -44,7 +45,8 @@ esp_err_t ws2812_control_init(void)
   return ESP_OK;
 }
 
-esp_err_t ws2812_write_leds(struct led_state new_state) {
+esp_err_t ws2812_write_leds(struct led_state new_state)
+{
   setup_rmt_data_buffer(new_state);
   ESP_RETURN_ON_ERROR(rmt_write_items(LED_RMT_TX_CHANNEL, led_data_buffer, LED_BUFFER_ITEMS, false), TAG, "Failed to write items");
   ESP_RETURN_ON_ERROR(rmt_wait_tx_done(LED_RMT_TX_CHANNEL, portMAX_DELAY), TAG, "Failed to wait for RMT transmission to finish");
@@ -52,16 +54,17 @@ esp_err_t ws2812_write_leds(struct led_state new_state) {
   return ESP_OK;
 }
 
-void setup_rmt_data_buffer(struct led_state new_state) 
+static void setup_rmt_data_buffer(struct led_state new_state)
 {
   for (uint32_t led = 0; led < NUM_LEDS; led++) {
     uint32_t bits_to_send = new_state.leds[led];
     uint32_t mask = 1 << (BITS_PER_LED_CMD - 1);
+
     for (uint32_t bit = 0; bit < BITS_PER_LED_CMD; bit++) {
       uint32_t bit_is_set = bits_to_send & mask;
-      led_data_buffer[led * BITS_PER_LED_CMD + bit] = bit_is_set ?
-                                                      (rmt_item32_t){{{T1H, 1, TL, 0}}} : 
-                                                      (rmt_item32_t){{{T0H, 1, TL, 0}}};
+      led_data_buffer[(led * BITS_PER_LED_CMD) + bit] = bit_is_set ?
+                                                      (rmt_item32_t){{{T1H, 1, T1L, 0}}} :
+                                                      (rmt_item32_t){{{T0H, 1, T0L, 0}}};
       mask >>= 1;
     }
   }

--- a/ws2812_control.h
+++ b/ws2812_control.h
@@ -5,7 +5,7 @@
 #include "sdkconfig.h"
 #include "esp_err.h"
 
-#define NUM_LEDS CONFIG_WS2812_NUM_LEDS
+#define NUM_LEDS	CONFIG_WS2812_NUM_LEDS
 
 // This structure is used for indicating what the colors of each LED should be set to.
 // There is a 32bit value for each LED. Only the lower 3 bytes are used and they hold the


### PR DESCRIPTION
I added some changes to the README.md I found in the Issues list.

I had some problems getting my NeoPixel to work at all, and found that using the timing values for the WS2811 worked. Since the datasheet has separate and different values for T0L and T1L, I changed Kconfig to add them as separate values.

Please let me know if you don't like any of these changes and I'll be happy to drop them.
Thanks!